### PR TITLE
Add refreshResults & Paginator

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -59,7 +59,7 @@ export class DuneClient {
   async runQuery(args: RunQueryArgs): Promise<ResultsResponse> {
     const { queryId, opts } = args;
     args.limit = opts?.batchSize || args.limit;
-    const { state, execution_id } = await this._runInner(
+    const { state, execution_id } = await this.refreshResults(
       queryId,
       args,
       opts?.pingFrequency,
@@ -89,7 +89,7 @@ export class DuneClient {
   async runQueryCSV(args: RunQueryArgs): Promise<ExecutionResponseCSV> {
     const { queryId, opts } = args;
     args.limit = opts?.batchSize || args.limit;
-    const { state, execution_id } = await this._runInner(
+    const { state, execution_id } = await this.refreshResults(
       queryId,
       args,
       opts?.pingFrequency,
@@ -186,26 +186,34 @@ export class DuneClient {
     return results;
   }
 
-  private async _runInner(
-    queryID: number,
+  /**
+   * Executes query with provided parameters, checking every `pingFrequency`
+   * seconds until execution status reaches a terminal state.
+   * @param queryId
+   * @param params
+   * @param pingFrequency
+   * @returns
+   */
+  async refreshResults(
+    queryId: number,
     params?: ExecutionParams,
     pingFrequency: number = POLL_FREQUENCY_SECONDS,
   ): Promise<GetStatusResponse> {
     log.info(
       logPrefix,
-      `refreshing query https://dune.com/queries/${queryID} with parameters ${JSON.stringify(
+      `refreshing query https://dune.com/queries/${queryId} with parameters ${JSON.stringify(
         params,
       )}`,
     );
-    const { execution_id: jobID } = await this.exec.executeQuery(queryID, params);
-    let status = await this.exec.getExecutionStatus(jobID);
+    const { execution_id } = await this.exec.executeQuery(queryId, params);
+    let status = await this.exec.getExecutionStatus(execution_id);
     while (!TERMINAL_STATES.includes(status.state)) {
       log.info(
         logPrefix,
-        `waiting for query execution ${jobID} to complete: current state ${status.state}`,
+        `waiting for query execution ${execution_id} to complete: current state ${status.state}`,
       );
       await sleep(pingFrequency);
-      status = await this.exec.getExecutionStatus(jobID);
+      status = await this.exec.getExecutionStatus(execution_id);
     }
     return status;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { DuneClient, QueryAPI, ExecutionAPI } from "./api";
 export * from "./types";
+export { Paginator } from "./paginator";

--- a/src/paginator.ts
+++ b/src/paginator.ts
@@ -1,0 +1,117 @@
+import { ExecutionAPI } from "./api";
+import { ExecutionState, GetStatusResponse } from "./types";
+
+export interface Page {
+  number: number;
+  values: Record<string, unknown>[];
+}
+
+export class Paginator {
+  private client: ExecutionAPI;
+  private executionId: string;
+  private pageSize: number;
+  private currentPageNumber: number;
+  pageCache: Map<number, Page>;
+  totalRows: number;
+
+  private constructor(
+    client: ExecutionAPI,
+    executionId: string,
+    pageSize: number,
+    firstPage: Page,
+    totalRows: number,
+  ) {
+    this.client = client;
+    this.executionId = executionId;
+    this.pageSize = pageSize;
+    this.currentPageNumber = firstPage.number;
+    this.pageCache = new Map();
+    this.pageCache.set(this.currentPageNumber, firstPage);
+    this.totalRows = totalRows;
+  }
+
+  static async new(
+    client: ExecutionAPI,
+    executionStatus: GetStatusResponse,
+    pageLimit: number,
+  ): Promise<Paginator> {
+    if (executionStatus.state !== ExecutionState.COMPLETED) {
+      throw new Error("Paginator can only be constructed on Complete execution state.");
+    }
+    const executionId = executionStatus.execution_id;
+    const results = await client.getExecutionResults(executionId, {
+      limit: pageLimit,
+      offset: 0,
+    });
+
+    if (!results.result) {
+      throw new Error("Can't paginate execution without results.");
+    }
+    const totalRows = results.result.metadata.total_row_count;
+    const firstPage = {
+      number: 1,
+      values: results.result.rows,
+    };
+    return new Paginator(client, executionId, pageLimit, firstPage, totalRows);
+  }
+
+  maxPage(): number {
+    return Math.ceil(this.totalRows / this.pageSize);
+  }
+
+  async nextPage(): Promise<Page | undefined> {
+    if (this.currentPageNumber < this.maxPage()) {
+      const nextPage = await this.getPage(this.currentPageNumber + 1);
+      this.currentPageNumber++;
+      return nextPage;
+    } else {
+      console.log("You are already on the last page!");
+    }
+  }
+
+  async previousPage(): Promise<Page | undefined> {
+    if (this.currentPageNumber > 1) {
+      const previousPage = await this.getPage(this.currentPageNumber - 1);
+      this.currentPageNumber--;
+      return previousPage;
+    } else {
+      console.log("You are already on the first page.");
+    }
+  }
+
+  async lastPage(): Promise<Page | undefined> {
+    const lastPage = await this.getPage(this.maxPage());
+    this.currentPageNumber = this.maxPage();
+    return lastPage;
+  }
+
+  async getPage(n: number): Promise<Page | undefined> {
+    if (n >= 1 && n <= this.maxPage()) {
+      if (this.pageCache.has(n)) {
+        return this.pageCache.get(n)!;
+      }
+      const pageNResults = await this.client.getExecutionResults(this.executionId, {
+        limit: this.pageSize,
+        // Page 1 has offset 0.
+        offset: this.pageSize * (n - 1),
+      });
+      if (!pageNResults.result) {
+        throw new Error(`Expected results for page ${n} of ${this.maxPage}`);
+      }
+      const pageN = {
+        number: n,
+        values: pageNResults.result.rows,
+      };
+      this.pageCache.set(n, pageN);
+      return pageN;
+    } else {
+      console.warn(
+        `Invalid page number requested ${n}: Must be contained in [1, ${this.maxPage()}]`,
+      );
+    }
+  }
+
+  public getCurrentPageValues(): Page {
+    return this.pageCache.get(this.currentPageNumber)!;
+  }
+}

--- a/src/paginator.ts
+++ b/src/paginator.ts
@@ -64,9 +64,8 @@ export class Paginator {
       const nextPage = await this.getPage(this.currentPageNumber + 1);
       this.currentPageNumber++;
       return nextPage;
-    } else {
-      console.log("You are already on the last page!");
     }
+    console.warn("You are already on the last page!");
   }
 
   async previousPage(): Promise<Page | undefined> {
@@ -74,9 +73,8 @@ export class Paginator {
       const previousPage = await this.getPage(this.currentPageNumber - 1);
       this.currentPageNumber--;
       return previousPage;
-    } else {
-      console.log("You are already on the first page.");
     }
+    console.warn("You are already on the first page.");
   }
 
   async lastPage(): Promise<Page | undefined> {
@@ -104,11 +102,10 @@ export class Paginator {
       };
       this.pageCache.set(n, pageN);
       return pageN;
-    } else {
-      console.warn(
-        `Invalid page number requested ${n}: Must be contained in [1, ${this.maxPage()}]`,
-      );
     }
+    console.warn(
+      `Invalid page number requested ${n}: Must be contained in [1, ${this.maxPage()}]`,
+    );
   }
 
   public getCurrentPageValues(): Page {

--- a/tests/e2e/client.spec.ts
+++ b/tests/e2e/client.spec.ts
@@ -25,7 +25,7 @@ describe("DuneClient Extensions", () => {
     });
     expect(results.result?.rows).to.be.deep.equal([
       {
-        date_field: "2022-05-04 00:00:00.000",
+        date_field: "2022-05-04 00:00:00",
         list_field: "Option 1",
         number_field: "3.1415926535",
         text_field: "Plain Text",
@@ -64,7 +64,7 @@ describe("DuneClient Extensions", () => {
     expect(results.data).to.be.equal(
       [
         "text_field,number_field,date_field,list_field\n",
-        "Plain Text,3.1415926535,2022-05-04 00:00:00.000,Option 1\n",
+        "Plain Text,3.1415926535,2022-05-04 00:00:00,Option 1\n",
       ].join(""),
     );
 

--- a/tests/e2e/execution.spec.ts
+++ b/tests/e2e/execution.spec.ts
@@ -168,7 +168,7 @@ describe("ExecutionAPI: native routes", () => {
     });
     expect(results.result?.rows).to.be.deep.equal([
       {
-        date_field: "2022-05-04 00:00:00.000",
+        date_field: "2022-05-04 00:00:00",
         list_field: "Option 1",
         number_field: "3.1415926535",
         text_field: "Plain Text",
@@ -183,15 +183,15 @@ describe("ExecutionAPI: native routes", () => {
     });
     const expectedRows = [
       "text_field,number_field,date_field,list_field\n",
-      "Plain Text,3.1415926535,2022-05-04 00:00:00.000,Option 1\n",
+      "Plain Text,3.1415926535,2022-05-04 00:00:00,Option 1\n",
     ];
     expect(resultCSV.data).to.be.eq(expectedRows.join(""));
   });
 
   /// Pagination
   it("uses pagination parameters", async () => {
-    // This execution was run with StartFrom = 1.
-    const result = await client.getExecutionResults("01HQJ996M17AB1D7EWDMPZ79ZS", {
+    // This execution was run with StartFrom = 1 on queryId = 3463180.
+    const result = await client.getExecutionResults("01HZ0KTJEC24251CM5SN8FFR26", {
       limit: 2,
       offset: 1,
     });
@@ -204,7 +204,7 @@ describe("ExecutionAPI: native routes", () => {
       },
     ]);
 
-    const resultCSV = await client.getResultCSV("01HQJ996M17AB1D7EWDMPZ79ZS", {
+    const resultCSV = await client.getResultCSV("01HZ0KTJEC24251CM5SN8FFR26", {
       limit: 1,
       offset: 2,
     });

--- a/tests/e2e/paginator.spec.ts
+++ b/tests/e2e/paginator.spec.ts
@@ -1,0 +1,61 @@
+import { expect } from "chai";
+import { DuneClient, Paginator } from "../../src/";
+import { BASIC_KEY } from "./util";
+
+describe("Paginator Class", () => {
+  let client: DuneClient;
+
+  before(() => {
+    client = new DuneClient(BASIC_KEY);
+  });
+  it("Paginator does the stuff", async () => {
+    // Ususally the user would call: client.refreshResults(:966920);
+    // But here we use existinc completed execution state.
+    const status = await client.exec.getExecutionStatus("01HZ0JYRJVN5MGG2CN8PAK63MT");
+    // Example usage:
+    const paginator = await Paginator.new(client.exec, status, 2);
+    expect(paginator.maxPage()).to.be.eq(5);
+    const pageOne = {
+      number: 1,
+      values: [
+        {
+          hash: "0x88e96d4537bea4d9c05d12549907b32561d3bf31f45aae734cdc119f13406cb6",
+          number: 1,
+        },
+        {
+          hash: "0xb495a1d7e6663152ae92708da4843337b958146015a2802f4193a410044698c9",
+          number: 2,
+        },
+      ],
+    };
+    const pageTwo = {
+      number: 2,
+      values: [
+        {
+          hash: "0x3d6122660cc824376f11ee842f83addc3525e2dd6756b9bcf0affa6aa88cf741",
+          number: 3,
+        },
+        {
+          hash: "0x23adf5a3be0f5235b36941bcb29b62504278ec5b9cdfa277b992ba4a7a3cd3a2",
+          number: 4,
+        },
+      ],
+    };
+    expect(paginator.getCurrentPageValues()).to.be.deep.eq(pageOne);
+    await paginator.nextPage(); // Move to page 2
+    expect(paginator.getCurrentPageValues()).to.be.deep.eq(pageTwo);
+    await paginator.previousPage(); // Move back to page 1
+    expect(paginator.getCurrentPageValues()).to.be.deep.eq(pageOne);
+    const lastPage = {
+      number: 5,
+      values: [
+        {
+          hash: "0x997e47bf4cac509c627753c06385ac866641ec6f883734ff7944411000dc576e",
+          number: 9,
+        },
+      ],
+    };
+    await paginator.lastPage(); // Jump to page 5
+    expect(paginator.getCurrentPageValues()).to.be.deep.eq(lastPage);
+  });
+});


### PR DESCRIPTION
We rename a previously internal method `_runInner` to `refreshResults` which executes and loops until execution is complete (but does not fetch results). Additionally, we Introduce a new class `Paginator` which fetches and caches and index result sets by page. This class exposes an api similar to the Dune interface result page navigation:

- nextPage, previousPage, lastPage and pageN.

Paginator can be constructed from the return value of `refreshResults` and a client of type `ExecutionAPI`.

Will want to add docs on how to use this, but the test introduced should give a pretty good idea of how to test it out in a front end.

**Note that** 
1. the first commit (https://github.com/duneanalytics/ts-dune-client/pull/53/commits/00ac359a5bc0cab8efaedd2ee9ad16f631efba1e) is unrelated (fixing e2e test based on Dune's internal data format changes and expired query results).
2. the second commit (https://github.com/duneanalytics/ts-dune-client/pull/53/commits/774b78912481c318081a9ae8320bfaa5970bfb39) is just renaming an existing function and making it public (in preparation for public use)

3. 🔑 the third commit (https://github.com/duneanalytics/ts-dune-client/pull/53/commits/69c3088aae8f4f9122f511fbb8bc3e045a8fa46d) This is the most relevant and substantial change introduced here: Paginator 📃 


cc @agaperste.