### PR TITLE
[Hotfix] Simplify router._handleResponse

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duneanalytics/client-sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Ben Smith <bh2smith@gmail.com>",
   "description": "Node Client for Dune Analytics' officially supported API.",
   "repository": "git@github.com:duneanalytics/ts-dune-client.git",

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -58,14 +58,12 @@ export class Router {
       const response = await responsePromise;
       if (!response.ok) {
         const errorText = await response.text();
-        throw new DuneError(
-          `HTTP error! Status: ${response.status}, Message: ${errorText}`,
-        );
+        throw new DuneError(`HTTP - Status: ${response.status}, Message: ${errorText}`);
       }
 
       return (await response.json()) as T;
     } catch (error) {
-      log.error(logPrefix, `caught unhandled response error ${JSON.stringify(error)}`);
+      log.error(logPrefix, error);
       throw new DuneError(`Response ${error}`);
     }
   }

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -136,6 +136,13 @@ export interface ResultsResponse extends TimeData {
   state: ExecutionState;
   // only present when state is COMPLETE
   result?: ExecutionResult;
+  error?: ErrorResult;
+}
+
+export interface ErrorResult {
+  type: string;
+  message: string;
+  metadata?: { line: number; column: number };
 }
 
 export interface LatestResultsResponse {

--- a/tests/e2e/query.spec.ts
+++ b/tests/e2e/query.spec.ts
@@ -2,8 +2,6 @@ import { expect } from "chai";
 import { QueryParameter, QueryAPI } from "../../src";
 import { PLUS_KEY, BASIC_KEY, expectAsyncThrow } from "./util";
 
-const PREMIUM_PLAN_MESSAGE = `HTTP Error - Status: 403, Message: {"error":"Query management endpoints are only available in our paid plans. Please upgrade to a paid plan to use it."}`;
-
 describe("QueryAPI: Premium - CRUD Operations", () => {
   let plusClient: QueryAPI;
 
@@ -53,13 +51,13 @@ describe("QueryAPI: Errors", () => {
     basicClient = new QueryAPI(BASIC_KEY);
   });
 
-  it.only("Basic Plan Failure", async () => {
+  it("Basic Plan Failure", async () => {
     await expectAsyncThrow(
       basicClient.createQuery({
         name: "Query Name",
         query_sql: "select 1",
       }),
-      `Response Error: ${PREMIUM_PLAN_MESSAGE}`,
+      `Response Error: HTTP - Status: 403, Message: {"error":"Query management endpoints are only available in our paid plans. Please upgrade to a paid plan to use it."}`,
     );
   });
 });

--- a/tests/e2e/query.spec.ts
+++ b/tests/e2e/query.spec.ts
@@ -2,8 +2,7 @@ import { expect } from "chai";
 import { QueryParameter, QueryAPI } from "../../src";
 import { PLUS_KEY, BASIC_KEY, expectAsyncThrow } from "./util";
 
-const PREMIUM_PLAN_MESSAGE =
-  "Response Error: Query management endpoints are only available in our paid plans. Please upgrade to a paid plan to use it.";
+const PREMIUM_PLAN_MESSAGE = `HTTP Error - Status: 403, Message: {"error":"Query management endpoints are only available in our paid plans. Please upgrade to a paid plan to use it."}`;
 
 describe("QueryAPI: Premium - CRUD Operations", () => {
   let plusClient: QueryAPI;
@@ -32,8 +31,6 @@ describe("QueryAPI: Premium - CRUD Operations", () => {
   it("unarchive, make public, make private, rearchive", async () => {
     const queryId = 3530410;
     let query = await plusClient.readQuery(queryId);
-    expect(query.is_archived).to.be.equal(true);
-    expect(query.is_private).to.be.equal(true);
 
     await plusClient.unarchiveQuery(queryId);
     await plusClient.makePublic(queryId);

--- a/tests/e2e/query.spec.ts
+++ b/tests/e2e/query.spec.ts
@@ -53,13 +53,13 @@ describe("QueryAPI: Errors", () => {
     basicClient = new QueryAPI(BASIC_KEY);
   });
 
-  it("Basic Plan Failure", async () => {
+  it.only("Basic Plan Failure", async () => {
     await expectAsyncThrow(
       basicClient.createQuery({
         name: "Query Name",
         query_sql: "select 1",
       }),
-      PREMIUM_PLAN_MESSAGE,
+      `Response Error: ${PREMIUM_PLAN_MESSAGE}`,
     );
   });
 });


### PR DESCRIPTION
This was not working for `queryId=3881689`. 
Still unclear why, but this simplification makes sense anyway. 