### PR TITLE
Ensure Package.json Availability

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dist/**/*"
   ],
   "scripts": {
-    "build": "rm -rf dist/* && yarn build:esm && yarn build:cjs",
+    "build": "rm -rf dist/* && yarn build:esm && yarn build:cjs && cp package.json dist",
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "test": "jest",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,6 @@
     
     "rootDir": "src"
   },
-  "include": ["src"],
+  "include": ["src", "package.json"],
   "exclude": ["node_modules", "dist", "tests"] // Added "dist" to avoid recompiling the output
 }


### PR DESCRIPTION
Now that we provide ESM and CJS builds, the router.ts file is reading from this (for version). We need to ensure the package.json is available.


TODO - need to come up with a way of determining version without importing package.json