### PR TITLE
Remove npm tokens usage

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -7,6 +7,9 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches npm publish to OIDC with provenance and ignores scripts, removing the token-based publish step.
> 
> - **CI** (`.github/workflows/npm-publish.yaml`):
>   - Replace token-based `npm publish` with OIDC: `npm publish --access public --provenance --ignore-scripts`.
>   - Remove `NODE_AUTH_TOKEN` usage in publish step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 041bf8e7e8cb7dafb5b4991e878067bcd13fe509. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->