### PR TITLE
Update npm-publish.yaml

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/
@@ -27,4 +27,4 @@ jobs:
           VERSION=${GITHUB_REF#refs/tags/}
           npm version $VERSION --no-git-tag-version
       - name: Publish to npm (OIDC)
-        run: npm publish --access public --provenance --ignore-scripts
+        run: npm publish --access public --ignore-scripts


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update npm publish workflow to use setup-node v5 and remove the --provenance flag from the publish step.
> 
> - **CI/CD**:
>   - Update workflow `/.github/workflows/npm-publish.yaml`:
>     - Bump `actions/setup-node` from `v4` to `v5`.
>     - Adjust publish step: remove `--provenance` from `npm publish` (keeps `--access public --ignore-scripts`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bf6f00224a415e17a893c00323936f28b114c87. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->