### PR TITLE
fix: resolve CodeQL security alerts

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -5,6 +5,9 @@ on:
     branches: ["main"]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/src/types/requestArgs.ts
+++ b/src/types/requestArgs.ts
@@ -166,7 +166,7 @@ export function validateAndBuildGetResultParams({
       // Check if the column contains quotes
       if (column.includes('"')) {
         // Escape quotes and add quotes around the entire string
-        return `"${column.replace(/"/g, '\\"')}"`;
+        return `"${column.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
       } else {
         // Leave the column unchanged
         return column;


### PR DESCRIPTION
## Summary

- **Incomplete string escaping** (`src/types/requestArgs.ts`): Column name sanitization escaped double quotes but not backslashes, allowing a crafted input like `foo\"` to break out of quoting. Fixed by escaping backslashes before quotes.
- **Missing workflow permissions** (`.github/workflows/pull-request.yaml`): CI workflow had no `permissions` block, giving the GITHUB_TOKEN broad default access. Added `contents: read` at the workflow level following least-privilege.

Resolves all 3 open CodeQL code scanning alerts:
- https://github.com/duneanalytics/ts-dune-client/security/code-scanning/1
- https://github.com/duneanalytics/ts-dune-client/security/code-scanning/2
- https://github.com/duneanalytics/ts-dune-client/security/code-scanning/3

## Test plan

- [ ] CI passes (lint, build, tests)
- [ ] CodeQL re-scan shows alerts resolved