### PR TITLE
chore: add pnpm install gate config + pin pnpm (PLA-2135)

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - uses: actions/setup-node@v5
         with:
           node-version: 20

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -18,8 +18,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Use Node.js
         uses: actions/setup-node@v4
@@ -49,8 +47,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -18,13 +18,9 @@
     "fmt": "prettier --write \"./**/*.ts\"",
     "lint": "eslint ./src && prettier --check \"./**/*.ts\""
   },
+  "packageManager": "pnpm@10.29.2",
   "dependencies": {
     "loglevel": "^1.9.2"
-  },
-  "pnpm": {
-    "overrides": {
-      "flatted": ">=3.4.2"
-    }
   },
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+minimumReleaseAge: 4320
+
+onlyBuiltDependencies:
+  - esbuild
+
+overrides:
+  flatted: ">=3.4.2"


### PR DESCRIPTION
## What

- Add `pnpm-workspace.yaml` with:
  - `minimumReleaseAge: 4320` (3-day publish-recency cooldown)
  - `onlyBuiltDependencies: [esbuild]` (block arbitrary install lifecycle scripts)
  - `overrides: { flatted: ">=3.4.2" }` (moved from the package.json `pnpm` field)
- Pin `packageManager` to `pnpm@10.29.2` in `package.json`.

## Why

Part of the PLA-2135 npm install gate rollout. This repo previously had no `pnpm-workspace.yaml` and no pinned package manager. Adding the native cooldown + lifecycle-script blocking brings it in line with the rest of our pnpm repos.

## Notes

- pnpm 10 no longer reads the `pnpm` field in `package.json`, so the existing `flatted` override was moved to `pnpm-workspace.yaml` to keep it working.
- Pinned `pnpm@10.29.2` (matching `core/core-node`). The version `10.29.0` does not exist on the registry.
- `pnpm install --lockfile-only` re-resolves cleanly with no lockfile churn.
