### PR TITLE
harden npm self-bootstrap in publish workflow (PLA-2135)

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -19,7 +19,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
           cache: "pnpm"
       - name: Update npm
-        run: npm install -g npm@11.5.1
+        run: npm install -g npm@11.5.1 --ignore-scripts
       - name: Get npm version
         run: npm --version
       - name: Build & Set Package Version to Tag


### PR DESCRIPTION
## Summary
- Follow-up to #99 (already merged), so this lands as a new PR off `main`.
- Adds `--ignore-scripts` to the pinned `npm install -g npm@11.5.1` step in `.github/workflows/npm-publish.yaml`.

## Rationale
The version pin already prevents pulling a newer (potentially compromised) npm. The remaining gap is that the global install still executed install lifecycle scripts. npm ships prebuilt with bundled deps and needs no build scripts, so `--ignore-scripts` is a zero-downside defense-in-depth measure, consistent with the `--ignore-scripts` already used on the publish step.
