### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code owners for ts-dune-client
+# Owners are automatically requested for review on PRs touching matched paths.
+# Docs: https://docs.github.com/articles/about-code-owners
+
+* @bh2smith


### PR DESCRIPTION
## What

Adds a `.github/CODEOWNERS` file assigning `@bh2smith` as the default owner for all paths.

## Why

The Vanta SLA report flagged this repo as having no CODEOWNERS file, so dependency/security obligations were assigned to a *likely* owner based on recent commits rather than an explicit one. This makes ownership explicit and auto-requests review on future PRs.

Adjust the owner(s) if a team handle (e.g. a `@duneanalytics/...` team) is preferred.