### PR TITLE
Fix flaky execution_ended_at assertion in cancelled-execution e2e test

### DIFF
--- a/tests/e2e/execution.spec.ts
+++ b/tests/e2e/execution.spec.ts
@@ -135,7 +135,8 @@ describe("ExecutionAPI: native routes", () => {
     // Verify timestamps exist (but don't check exact values since they're dynamic)
     expect(result.submitted_at).toBeDefined();
     expect(result.cancelled_at).toBeDefined();
-    expect(result.execution_ended_at).toBeUndefined();
+    // execution_ended_at is only set if the execution had started running when the
+    // cancel landed, so it's timing-dependent here and intentionally not asserted.
   });
 
   it("gets Results (with various optinal parameters)", async () => {


### PR DESCRIPTION
The e2e test `ExecutionAPI: native routes > returns expected results on cancelled query execution` has been failing on `main` because it asserted `result.execution_ended_at` to be `undefined`, but the live API returned a timestamp.

This is not an API semantics change — it's a timing race the assertion papered over. `execution_ended_at` is only populated when the cancel lands on an execution that had already started running; when the cancel catches it in `PENDING`, the field stays undefined. The test executes then immediately cancels, so which outcome occurs depends on scheduling.

The assertion had already been flipped once before (`toBeDefined` → `toBeUndefined` in "try and fix tests"), which is the classic signature of pinning a flaky test to whatever a single run happened to return.

Rather than bet on either value, this drops the `execution_ended_at` assertion entirely. The meaningful behavior is still verified: `state === CANCELLED`, and that `submitted_at` and `cancelled_at` are set.
